### PR TITLE
Allow runtime 'requestTimeout' change for proxy's store requests

### DIFF
--- a/internal/store/k8s.go
+++ b/internal/store/k8s.go
@@ -349,6 +349,16 @@ func (s *KubeStore) GetProxiesInfo(ctx context.Context) (cluster.ProxiesInfo, er
 	return psi, nil
 }
 
+// dummy function
+func (s *KubeStore) GetRequestTimeout() (time.Duration, error) {
+	return 0, fmt.Errorf("KubeStore GetRequestTimeout() not applicable");
+}
+
+// dummy function
+func (s *KubeStore) SetRequestTimeout(newRequestTimeout time.Duration) error {
+	return fmt.Errorf("KubeStore SetRequestTimeout() not applicable")
+}
+
 type KubeElection struct {
 	client       *kubernetes.Clientset
 	podName      string

--- a/internal/store/kvbacked.go
+++ b/internal/store/kvbacked.go
@@ -345,6 +345,21 @@ func (s *KVBackedStore) GetProxiesInfo(ctx context.Context) (cluster.ProxiesInfo
 	return psi, nil
 }
 
+func (s *KVBackedStore) GetRequestTimeout() (time.Duration, error) {
+	if i, ok := s.store.(*etcdV3Store); ok {
+		return i.requestTimeout, nil;
+	}
+	return 0, fmt.Errorf("failed to get requestTimeout");
+}
+
+func (s *KVBackedStore) SetRequestTimeout(newRequestTimeout time.Duration) error {
+	if i, ok := s.store.(*etcdV3Store); ok {
+		i.requestTimeout = newRequestTimeout;
+		return nil;
+	}
+	return fmt.Errorf("failed to set requestTimeout")
+}
+
 func NewKVBackedElection(kvStore KVStore, path, candidateUID string, timeout time.Duration) Election {
 	switch kvStore := kvStore.(type) {
 	case *libKVStore:

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -41,6 +41,9 @@ type Store interface {
 	GetSentinelsInfo(ctx context.Context) (cluster.SentinelsInfo, error)
 	SetProxyInfo(ctx context.Context, pi *cluster.ProxyInfo, ttl time.Duration) error
 	GetProxiesInfo(ctx context.Context) (cluster.ProxiesInfo, error)
+	// Gets|Sets store 'requestTimeout' if applicable
+	GetRequestTimeout() (time.Duration, error)
+	SetRequestTimeout(newRequestTimeout time.Duration) error
 }
 
 type Election interface {


### PR DESCRIPTION
Make it possible to change `requestTimeout` for proxy's `CheckCluster()` pinger in realtime. Modifying only `proxyCheckInterval` and/or `proxyTimeout`doesn't help in the case of slow etcd.
Previously, this parameter in cluster data changed, but the running proxy did not react on it.